### PR TITLE
adds in some slack instructions

### DIFF
--- a/server.py
+++ b/server.py
@@ -144,5 +144,15 @@ def privacy_policy(db):
     return static_file('privacy_policy.txt', root=settings.TEMPLATE_PATH)
 
 
+@route('/slack_instructions/')
+def slack_instructions(db):
+    return template(
+        'slack_instructions',
+        slack_client_id=settings.SLACK_OAUTH['client_id'],
+        slack_command_scope=settings.SLACK_OAUTH['command_scope'],
+        slack_installed=strtobool(request.GET.get('added_to_slack', 'false')),
+    )
+
+
 if __name__ == '__main__':
     run(host='127.0.0.1', port=8088, debug=False)

--- a/templates/common/add_to_slack_button.tpl
+++ b/templates/common/add_to_slack_button.tpl
@@ -1,0 +1,1 @@
+<a href="https://slack.com/oauth/authorize?scope={{slack_command_scope}}&client_id={{slack_client_id}}"><img alt="Add to Slack" height="40" width="139" src="https://platform.slack-edge.com/img/add_to_slack.png" srcset="https://platform.slack-edge.com/img/add_to_slack.png 1x, https://platform.slack-edge.com/img/add_to_slack@2x.png 2x" /></a>

--- a/templates/common/header.tpl
+++ b/templates/common/header.tpl
@@ -10,4 +10,5 @@
  <div><a href="/">Home</a></div>
  <div><a href="/contact/">Contact</a></div>
  <div><a href="/privacy/">Privacy</a></div>
+ <div><a href="/slack_instructions/">How-To Slack</a></div>
 </div>

--- a/templates/home.tpl
+++ b/templates/home.tpl
@@ -8,6 +8,8 @@
 %if slack_installed:
 <center><H5>You seem to have successfully installed xqz.es for slack, <a href=https://slack.com/apps/manage>manage your apps</a> to approve it if necessary</H5></center>
 %else:
-<center><a href="https://slack.com/oauth/authorize?scope={{slack_command_scope}}&client_id={{slack_client_id}}"><img alt="Add to Slack" height="40" width="139" src="https://platform.slack-edge.com/img/add_to_slack.png" srcset="https://platform.slack-edge.com/img/add_to_slack.png 1x, https://platform.slack-edge.com/img/add_to_slack@2x.png 2x" /></a></center>
+<center>
+%include common/add_to_slack_button
+</center>
 %end
 </html>

--- a/templates/slack_instructions.tpl
+++ b/templates/slack_instructions.tpl
@@ -1,0 +1,29 @@
+<html>
+<head>
+%include common/header
+</head>
+<body>
+
+<H2>How-To Slack</H2>
+<p>We think excuses are an important part of your life. Which is why
+we decided to build a slack app.</p>
+
+<p>After setting up the slack app, all you have to do to get an excuse
+if somebody's giving you a hard time is call the /xqzes command and we'll
+pick a random excuse for you. Some other options are available via the
+ '/xqzes help' command, but these merely ancillary.</p>
+
+<p>A final note, some of our excuses <b>are NSFW.</b></p>
+
+<p>To add xqz.es to your team, all you need to do is click the slack button
+on the home page (or below) and follow the instructions slack gives you. If you
+have any concerns about privacy, you can read our (rather succinct)
+<a href=/privacy/>privacy policy</a></p>
+
+%include common/add_to_slack_button
+
+<p>You're always welcome to <a href="/contact/">contact us</a> or
+<a href="https://github.com/arahayrabedian/xqz.es/issues/">open an issue on
+ Github</a></p>
+</body>
+</html>


### PR DESCRIPTION
solves #11 required for publishing slack app.
- adds slack instructions page (obvi)
- refactors Add To Slack button to abide by DRY, at the risk of DRY-ing on template contexts. - too early to boil the ocean and inject context everywhere.
