### PR TITLE
Web add

### DIFF
--- a/media/style.css
+++ b/media/style.css
@@ -26,11 +26,17 @@ a {
 #header ul li:hover { background: #fefcf2; cursor: pointer; }
 #header ul li:active { background: #fcf4d1; }
 
+/* FORMS FORMS FORMS */
 
-/* Contact Form */
+/* #general */
 .success { color: green; }
 .error { color: red; }
+div.g-recaptcha {
+  margin: 0 auto;
+  width: 304px;
+}
 
+/* Contact Form */
 #contact div { margin-bottom: 30px; }
 #contact label { font-weight: bold; margin-bottom: 10px; display: block; }
 #contact input { width: 100%; padding: 10px; font-size: 18px; }
@@ -46,3 +52,21 @@ a {
 }
 #contact button:hover { cursor: pointer; background: #d61136 }
 #contact .error { margin-top: 2px; }
+
+/* Repeating ourselves here for adding new submission */
+
+#submit div { margin-bottom: 30px; }
+#submit label { font-weight: bold; margin-bottom: 10px; display: block; }
+#submit input { width: 100%; padding: 10px; font-size: 18px; }
+#submit textarea { width: 100%; padding: 10px; font-size: 18px; }
+#submit button {
+	font-size: 22px;
+	font-weight: bold;
+	background: #ED1C43;
+	color: white;
+	border: none;
+	padding: 10px 20px;
+	border-radius: 2px;
+}
+#submit button:hover { cursor: pointer; background: #d61136 }
+#submit .error { margin-top: 2px; }

--- a/media/style.css
+++ b/media/style.css
@@ -22,7 +22,7 @@ a {
 	font-weight: bold;
 	border-radius: 4px;
 }
-#header ul li a { padding: 10px 20px; display: inline-block; }
+#header ul li a { padding: 0px 20px; display: inline-block; }
 #header ul li:hover { background: #fefcf2; cursor: pointer; }
 #header ul li:active { background: #fcf4d1; }
 

--- a/server.py
+++ b/server.py
@@ -161,14 +161,15 @@ def slack_instructions(db):
 
 
 @route('/submit/')
+@post('/submit/')
 def submit(db):
 
     # TODO: break this out along with others in to an excuses package.
     class SubmissionForm(Form):
-        attribution_name = StringField('Your Name (For Attribution purposes)',
+        attribution_name = StringField('Your Name (for future attribution purposes)',
                                        [validators.InputRequired()])
         excuse = TextAreaField(
-            'What\'s YOUR excuse??',
+            'What\'s YOUR excuse !?!?',
             [
                 validators.Length(
                     min=5,
@@ -187,7 +188,8 @@ def submit(db):
 
     submitted = False
     if request.method == 'POST' and form.validate():
-        excuse_record = Excuse(form.attribution_name, form.excuase)
+        excuse_record = Excuse(form.attribution_name.data,
+                               form.excuse.data)
         db.add(excuse_record)
         submitted = True
 

--- a/server.py
+++ b/server.py
@@ -91,31 +91,33 @@ def process_slack_command(db):
     # make our lives a little easier
     slack_data = DictObject(request.forms)
 
-    # match help text
-    if slack_data.text == 'help':
-        return {
-            "text": "Request this help text with `/xqzes help`\n"
-                    "Request an excuse (visible to everyone) with `/xqzes`\n"
-                    "Submit a new excuse to a moderator with "
-                    "`/xqzes add <your text here>`\n"
-                    "e.g: `/xqzes add I was shopping!`"
-        }
-    elif slack_data.text.startswith("add"):
-        # here we want to add a new non-approved excuse
-        excuse_text = slack_data.text.lstrip(" add ")
-        if len(excuse_text) > 140:
+    # small chance text is empty (if a stupid dev is curling manually)
+    if 'text' in slack_data.attributes.keys():
+        # match help text
+        if slack_data.text == 'help':
             return {
-                'text': "We conform to twitter standards (for no particular "
-                        "reason), please keep your excuses shorter than "
-                        "140 characters"
+                "text": "Request this help text with `/xqzes help`\n"
+                        "Request an excuse (visible to everyone) with `/xqzes`\n"
+                        "Submit a new excuse to a moderator with "
+                        "`/xqzes add <your text here>`\n"
+                        "e.g: `/xqzes add I was shopping!`"
             }
-        excuse = Excuse(slack_data.user_name, excuse_text)
-        excuse.team_id = slack_data.team_id
-        db.add(excuse)
-        return {
-            'text': "Your excuse has been added to the moderation queue. This "
-                    "can take anywhere from a few minutes to a few years"
-        }
+        elif slack_data.text.startswith("add"):
+            # here we want to add a new non-approved excuse
+            excuse_text = slack_data.text.lstrip(" add ")
+            if len(excuse_text) > 140:
+                return {
+                    'text': "We conform to twitter standards (for no particular "
+                            "reason), please keep your excuses shorter than "
+                            "140 characters"
+                }
+            excuse = Excuse(slack_data.user_name, excuse_text)
+            excuse.team_id = slack_data.team_id
+            db.add(excuse)
+            return {
+                'text': "Your excuse has been added to the moderation queue. This "
+                        "can take anywhere from a few minutes to a few years"
+            }
 
     try:
         excuse_text = Excuse.get_random_excuse(db).excuse

--- a/server.py
+++ b/server.py
@@ -92,7 +92,7 @@ def process_slack_command(db):
     slack_data = DictObject(request.forms)
 
     # small chance text is empty (if a stupid dev is curling manually)
-    if 'text' in slack_data.attributes.keys():
+    if 'text' in slack_data.attributes:
         # match help text
         if slack_data.text == 'help':
             return {

--- a/server.py
+++ b/server.py
@@ -168,8 +168,19 @@ def submit(db):
 
     # TODO: break this out along with others in to an excuses package.
     class SubmissionForm(Form):
-        attribution_name = StringField('Your Name (for future attribution purposes)',
-                                       [validators.InputRequired()])
+        attribution_name = StringField(
+            'Your Name (for future attribution purposes)',
+            [
+                validators.InputRequired(),
+                validators.Length(
+                    min=3,
+                    max=50,
+                    message="Srsly, give us a decent username "
+                            "(%(min)d - %(max)d chars),"
+                            " doesn't even have to be real."
+                )
+            ]
+        )
         excuse = TextAreaField(
             'What\'s YOUR excuse !?!?',
             [

--- a/templates/common/header.tpl
+++ b/templates/common/header.tpl
@@ -1,11 +1,11 @@
 <div id="header">
-	<img class="logo" src="/static/logo/xqzes_2000x500.png" alt="xqzes logo" style="width:20em;">
+	<a href="/"><img class="logo" src="/static/logo/xqzes_2000x500.png" alt="xqzes logo" style="width:20em;"></a>
 
 	<ul>
-		<li><a href="/">Home</a></li>
 		<li><a href="/contact/">Contact</a></li>
 		<li><a href="/privacy/">Privacy</a></li>
 		<li><a href="/slack_instructions/">How-To Slack</a></li>
 		<li><a href="/acknowledgements/">Acknowledgements</a></li>
+		<li><a href="/submit/">Add</a></li>
 	</ul>
 </div>

--- a/templates/common/header.tpl
+++ b/templates/common/header.tpl
@@ -2,10 +2,12 @@
 	<a href="/"><img class="logo" src="/static/logo/xqzes_2000x500.png" alt="xqzes logo" style="width:20em;"></a>
 
 	<ul>
-		<li><a href="/contact/">Contact</a></li>
-		<li><a href="/privacy/">Privacy</a></li>
-		<li><a href="/slack_instructions/">How-To Slack</a></li>
-		<li><a href="/acknowledgements/">Acknowledgements</a></li>
 		<li><a href="/submit/">Add</a></li>
+		<li><a href="/contact/">Contact</a></li>
+		<li><a href="/slack_instructions/">How-To Slack</a></li>
+	</ul>
+	<ul>
+		<li><a href="/acknowledgements/">Acknowledgements</a></li>
+		<li><a href="/privacy/">Privacy</a></li>
 	</ul>
 </div>

--- a/templates/contact.tpl
+++ b/templates/contact.tpl
@@ -24,7 +24,7 @@
             </div>
 
             <div>
-                <label>{{ !form.contact_text.label }}</label>
+                {{ !form.contact_text.label }}
                 {{ !form.contact_text }}
                 %for error in form.contact_text.errors:
                     <p class="error"> {{ error }}</p>
@@ -32,7 +32,7 @@
             </div>
 
             <div>
-                <label>{{ !form.nocaptcha }}</label>
+                {{ !form.nocaptcha }}
                 %for error in form.nocaptcha.errors:
                     <p class="error"> {{ error }}</p>
                 %end

--- a/templates/submit.tpl
+++ b/templates/submit.tpl
@@ -1,0 +1,44 @@
+<html>
+    <head>
+        <link rel="stylesheet" type="text/css" href="/static/style.css">
+    </head>
+
+    <body>
+        %include common/header
+
+        <H1>Submit a New Excuse</H1>
+
+        <p>Use this form to submit new excuses (subject to moderator approval)</p>
+
+        %if submitted:
+            <p class="success">Our moderators are gonna take their sweet time, but promise to take a look at your excuse... sooner or later.</p>
+        %end
+
+        <form id="submit" method="POST" action="/submit/">
+            <div>
+                <label>{{ !form.attribution_name.label }}</label>
+                {{ !form.attribution_name}}
+                %for error in form.attribution_name.errors:
+                    <p class="error">{{ error }}</p>
+                %end
+            </div>
+
+            <div>
+                <label>{{ !form.excuse.label }}</label>
+                {{ !form.excuse }}
+                %for error in form.excuse.errors:
+                    <p class="error"> {{ error }}</p>
+                %end
+            </div>
+
+            <div>
+                <label>{{ !form.nocaptcha }}</label>
+                %for error in form.nocaptcha.errors:
+                    <p class="error"> {{ error }}</p>
+                %end
+            </div>
+
+            <div><button type="submit">Excuse-ify! Enhance!</button></div>
+        </form>
+    </body>
+</html>

--- a/templates/submit.tpl
+++ b/templates/submit.tpl
@@ -24,7 +24,7 @@
             </div>
 
             <div>
-                <label>{{ !form.excuse.label }}</label>
+                {{ !form.excuse.label }}
                 {{ !form.excuse }}
                 %for error in form.excuse.errors:
                     <p class="error"> {{ error }}</p>
@@ -32,7 +32,7 @@
             </div>
 
             <div>
-                <label>{{ !form.nocaptcha }}</label>
+                {{ !form.nocaptcha }}
                 %for error in form.nocaptcha.errors:
                     <p class="error"> {{ error }}</p>
                 %end


### PR DESCRIPTION
solved #22 by adding a submission form on the webs, goes in to db as under moderation mode. 

Reuses existing 'username' field, but without a slack team - I worry this could cause issues in the future, but we can separate out if need by via script.

blank team id should be ok, it's not constrained to not-null, so yeah, we'll see how that goes.